### PR TITLE
Fix validate_numeric check for -I option

### DIFF
--- a/run_kssd3ani
+++ b/run_kssd3ani
@@ -125,7 +125,7 @@ validate_numeric() {
 validate_numeric "f" "$f_num"
 validate_numeric "C" "$C_num"
 validate_numeric "O" "$O_num"
-validate_numeric "I" "$O_num"
+validate_numeric "I" "$I_num"
 validate_numeric "m" "$m_num"
 validate_numeric "p" "$p_num"
 


### PR DESCRIPTION
## Summary
- correct argument to numeric validation for `-I` option in `run_kssd3ani`

## Testing
- `bash -n run_kssd3ani`

------
https://chatgpt.com/codex/tasks/task_e_6862883661f88326b080f55cee4c222e